### PR TITLE
[Flask UI] Added basic colorpicker styles for light controls

### DIFF
--- a/flaskUI/static/assets/script.js
+++ b/flaskUI/static/assets/script.js
@@ -13,6 +13,17 @@ $(document).ready(function() {
     $('.sidebar').toggleClass('active');
   });
 
+  /* colorpicker use https://iro.js.org/guide.html as reference*/
+  var colorPicker = new iro.ColorPicker('#colorPicker', {
+    layout: [
+      { 
+        component: iro.ui.Wheel,
+        options: {}
+      },
+    ]
+  });
+
+ /* ENDcolorpicker*/
 
   $('.slideContainer').change( function() {
             var element = $(this).parent().attr('id').split("_")[1]

--- a/flaskUI/static/assets/style.css
+++ b/flaskUI/static/assets/style.css
@@ -459,6 +459,74 @@ input[type="range"]::-ms-fill-upper {
 }
 /* END Light intensity slider */
 
+.expndGroupContainer{
+  width: 320px;
+  margin: 10px;
+  color:#eee;
+}
+
+.topBar{
+  position: relative;
+  width: 100%;
+}
+
+.topBar P{
+  margin: 0 0 10px 5px;
+  font-size: 14pt;
+}
+
+.topBar .btnBack{
+  width: 100px;
+  height: 40px;
+  background: rgba(0, 0, 0, .4);
+  position: absolute;
+  top: 0;
+  right:0;
+  border-top-right-radius: 8px;
+  border-top-left-radius: 8px;
+}
+
+.topBar .btnBack i{
+  margin: 10px 10px 0 10px;
+  font-size: 15pt;
+}
+
+
+
+.expndGroup {
+  width: 100%;
+  background: rgba(0, 0, 0, .4);
+  border-radius: 8px;
+  color:#eee;
+}
+
+.expndGroup .header{
+  position: relative;
+  width: 100%;
+  height: 75px;
+  background: #272727;
+  border-radius: 8px;
+  -webkit-box-shadow: 0px 0px 10px 1px rgb(0 0 0 / 50%);
+  box-shadow: 0px 0px 10px 1px rgb(0 0 0 / 50%);
+  overflow: hidden;
+  font-size: 14pt;
+  font-weight: 400;
+  margin-bottom: 20px;
+}
+
+.expndGroup .header .textContainer{
+  float: left;
+  height: 75px;
+  margin: 15px 0 0 20px;
+}
+
+.expndGroup .header .switchContainer{
+  float: right;
+  height: 75px;
+  margin: 15px 15px 0 0;
+}
+
+
 
 @media screen and (max-width: 750px) {
   body{
@@ -490,6 +558,11 @@ input[type="range"]::-ms-fill-upper {
 
   .contentContainer{
     margin: 0;
+  }
+
+  .expndGroupContainer{
+    width: 100%;
+    margin: 5px 0 0 0;
   }
 
 }


### PR DESCRIPTION
Hi,

I added a basic style for the colorpicker.
Todo @mariusmotea:

- Show a selector for each lamp on colorpicker
- Change headline to the name of the selected light in the colorpicker
- Change headline background color to selected light in the colorpicker
- Change headline slider to the brightness control of the selected light
- Show on group click(.overlayBtn) the new .expndGroupContainer. (Hide Group Container)

I add comments to the most important classes in the code. Hit me up if you need more explanation.

It should work like shown in the video.
https://user-images.githubusercontent.com/329471/110214352-7ce43900-7ea4-11eb-8f11-1d0002667984.mp4

Thank you
David
